### PR TITLE
Backend fix user prompt no audio in q

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+.env
+backend/.env
+venv/
+__pycache__/
+*.pyc
+.DS_Store
+.git/
+frontend/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,26 @@
+# backend/Dockerfile
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system deps
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements from backend/
+COPY backend/requirements.txt .
+
+# Install requirements
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy app files from backend/
+COPY backend/ .
+
+# Expose port
+EXPOSE 5001
+
+# Run app
+CMD ["gunicorn", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "-w", "1", "-b", "0.0.0.0:5001", "app:app"]

--- a/backend/SegmentTest.py
+++ b/backend/SegmentTest.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch
+import time
+from Segment import *
+
+class TestClearQBeyondXSeconds(unittest.TestCase):
+    def setUp(self):
+        self.seg = lambda d: Segment(duration=d)
+
+    @patch('time.time', return_value=210)
+    def test_clear_beyond_enough(self, mock_time):
+        tracker = SegmentsTracker([
+            self.seg(10), self.seg(5), self.seg(3), self.seg(4), self.seg(5)
+        ])
+        current_playback = {"segment": tracker.segments[0], "start_time": 200}
+        tracker.clearQBeyondXSeconds(10, current_playback)
+        self.assertEqual(len(tracker.segments), 4)  # 10s passed - only 1s left from seg0
+
+    @patch('time.time', return_value=205)
+    def test_clear_nothing_needed(self, mock_time):
+        tracker = SegmentsTracker([
+            self.seg(10), self.seg(5), self.seg(3)
+        ])
+        current_playback = {"segment": tracker.segments[0], "start_time": 200}
+        tracker.clearQBeyondXSeconds(4, current_playback)
+        self.assertEqual(len(tracker.segments), 1)  # 5s played, 5s left
+
+    @patch('time.time', return_value=215)
+    def test_clear_all_but_one(self, mock_time):
+        tracker = SegmentsTracker([
+            self.seg(10), self.seg(5), self.seg(3)
+        ])
+        current_playback = {"segment": tracker.segments[0], "start_time": 200}
+        tracker.clearQBeyondXSeconds(0, current_playback)
+        self.assertEqual(len(tracker.segments), 1)  # Only current seg kept
+
+    @patch('time.time', return_value=200)
+    def test_clear_none_all_needed(self, mock_time):
+        tracker = SegmentsTracker([
+            self.seg(4), self.seg(3), self.seg(3)
+        ])
+        current_playback = {"segment": tracker.segments[0], "start_time": 200}
+        tracker.clearQBeyondXSeconds(10, current_playback)
+        self.assertEqual(len(tracker.segments), 3)  # All needed to reach 10s
+
+    @patch('time.time', return_value=202)
+    def test_segment_time_left_is_zero(self, mock_time):
+        tracker = SegmentsTracker([
+            self.seg(2), self.seg(5), self.seg(5)
+        ])
+        current_playback = {"segment": tracker.segments[0], "start_time": 200}
+        tracker.clearQBeyondXSeconds(5, current_playback)
+        self.assertEqual(len(tracker.segments), 2)  # s0 expired, need s1 only to hit 5s
+    
+    @patch('time.time', return_value=202)
+    def test_blank_segments_to_clear(self, mock_time):
+        tracker = SegmentsTracker([])
+        current_playback = {"segment": None, "start_time": 200}
+        tracker.clearQBeyondXSeconds(5, current_playback)
+        self.assertEqual(len(tracker.segments), 0) 
+    
+    @patch('time.time', return_value=202)
+    def test_current_playback_is_none(self, mock_time):
+        tracker = SegmentsTracker([self.seg(4), self.seg(3)])
+        current_playback = None
+        tracker.clearQBeyondXSeconds(5, current_playback)
+        self.assertEqual(len(tracker.segments), 2) 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/app.py
+++ b/backend/app.py
@@ -148,9 +148,14 @@ def continousManageTopic():
                         conv_topic = new_topic
                         print(f'New Topic is set to: {new_topic}')
                     
+                    cp = None
+                    with current_playback_lock:
+                        cp = current_playback
+
                     with ST_lock:
                         if DEBUG: print("\t continuousManageTopic():148 st_lock")
-                        ST.clearQ()
+                        # ST.clearQ()
+                        ST.clearQBeyondXSeconds(35, cp)
                         ST.add_segment(transition_segment)
                         for _ in range(INFLUENCE_DEGREE):
                             ST.add_segment(Segment(conv_topic=new_topic))

--- a/backend/app.py
+++ b/backend/app.py
@@ -129,7 +129,7 @@ def continousManageTopic():
             if new_topic:
                 with ST_lock:
                     if DEBUG: print("\t continuousManageTopic():127 st_lock")
-                    latest_segment = ST.get_first_segment()
+                    latest_segment = ST.get_first_segment() # TODO make this to be smart about which segments it gives for context
                     latest_script = ([{'speaker_name': latest_segment.speaker_name, 'text': latest_segment.text}] if latest_segment else [])
                 
                 transition_script = generateContent.generateNewTopicContent(
@@ -160,6 +160,8 @@ def continousManageTopic():
                         for _ in range(INFLUENCE_DEGREE):
                             ST.add_segment(Segment(conv_topic=new_topic))
                         print(f'Segments is now {len(ST.segments)} long')
+                        if len(ST.segments) < MIN_Q_SIZE:
+                            loadAnotherTopic()
                     
                     broadcastNewTopic(new_topic)
         

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,11 +1,12 @@
 Flask
 groq
 flask_cors
-dotenv
+python-dotenv
 soundfile
 flask_socketio
 requests
 gunicorn
+gevent
 gevent-websocket
 pydub
-ffmpeg
+ffmpeg-python

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,29 @@
+# fly.toml file for the ForeverFM app
+
+# App name should be a simple string, not an object
+app = "foreverfm"  # Your app name
+
+# Docker build configuration
+[build]
+  dockerfile = "./backend/Dockerfile"  # Path to your Dockerfile
+
+# Configuring services
+[[services]]
+  internal_port = 5001  # The port your Flask app is running on
+
+  # Expose HTTP and HTTPS ports
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+# Autoscaling settings (optional)
+[services.autoscaling]
+  min_instances = 1
+  max_instances = 3
+
+[[services.tls_options]]
+  min_version = "tls1.2"  # Ensure TLS 1.2 or higher for security


### PR DESCRIPTION
When a user prompt is created, the Segment Q is cleared except for one item. This did not always allow enough time to generate the script and audio to reply to the user and would result in no audio playing. This quickfix, sets a hard rule of "at least 35 seconds of existing audio will keep playing" before any user prompts are played.  We can tweak this 35seconds magic number.